### PR TITLE
change vol information to avoid errors on non linux hosts

### DIFF
--- a/docker/aarc_dev/api/Dockerfile
+++ b/docker/aarc_dev/api/Dockerfile
@@ -5,4 +5,5 @@ ARG AUTH_PATH="/usr/src/aarc"
 
 WORKDIR ${AUTH_PATH}/api
 RUN ls
+RUN npm i -g nodemon
 CMD ["npm", "run", "dev"]

--- a/docker/aarc_dev/docker-compose.yml
+++ b/docker/aarc_dev/docker-compose.yml
@@ -35,9 +35,11 @@ services:
         ports:
             - "27217:${DATABASE_INTERNAL_PORT}"
         volumes:
-            - "/home/ec2-user/auth_data:/data/db"
+            - "aarcdb-data:/data/db"
         networks:
             - aarc-parent
+volumes:
+    aarcdb-data:
 networks:
     aarc-parent:
         name: devlvl_net


### PR DESCRIPTION
### Description

to avoid errors on non linux hosts from filesystem structure differences, changes to the `aarc_dev` docker-compose file need to be made for the database volume information

### Changes

* add docker vol
* change the volume information for the aarc db 

### Resolves

ref card: https://trello.com/c/vfIk7150